### PR TITLE
Fixing prerm bug

### DIFF
--- a/templates/prerm
+++ b/templates/prerm
@@ -9,7 +9,7 @@ declare -r service_name='{{ node_deb_package_name }}'
 if hash systemctl 2> /dev/null; then
   if [[ "$init_type" == 'auto' || "$init_type" == 'systemd' ]]; then
     systemctl disable "$service_name.service" && \
-    systemctl stop "$service_name.service}" || \
+    systemctl stop "$service_name.service" || \
     echo "$service_name wasn't even running!"
   fi
 elif hash service 2> /dev/null; then


### PR DESCRIPTION
- There was a spurious ending brace (`}`) causing systemd services to not be stopped properly.

I did not add a test for this as I could not get the test suite running locally. I tried to run `./test.sh` but it complained about vagrant. After installing vagrant there were still problems. Perhaps you could use a more lightweight virtualization system for this somehow? If so, then you could even run the `test.sh` script on travis or such. :-)