### PR TITLE
populate new node_modules for debian package

### DIFF
--- a/node-deb
+++ b/node-deb
@@ -40,7 +40,7 @@ readlink_f() {
 node_deb_dir="$(dirname "$(readlink_f "${BASH_SOURCE[0]}")")"
 declare -r node_deb_dir
 
-# the absolute path of the target protject's source code on the system
+# the absolute path of the target project's source code on the system
 source_dir="$(readlink_f "$(pwd)")"
 declare -r source_dir
 
@@ -667,8 +667,8 @@ ln -sf "/usr/share/$package_name/bin/$executable_name" "$deb_dir/usr/bin/$execut
 log_info 'Recursively copying files into Debian directory'
 if echo "$@" | grep -q 'node_modules'; then
   log_warn "Since node-deb v0.6.0, 'node_modules' is automatically included and should not be specified on the" \
-    "command line. Only production files are included via 'npm ls --prod'. Inclusion of 'node_modules' will" \
-    'result in an error in future releases.'
+    "command line. Only production files are included by building a new 'node_modules' dir for the debian package" \
+    "Inclusion of 'node_modules' will result in an error in future releases."
 fi
 
 if echo "$@" | grep -q 'package.json'; then
@@ -698,24 +698,32 @@ find "$@" -type f -print0 | {
   done
 }
 
-if [ -d "$source_dir/node_modules" ]; then
-  npm ls --parseable --prod | sed -e "s/$(escape "$source_dir")//g" | grep -Ev '^$' | sed -e 's:/node_modules/::g' | {
-    while IFS="\n" read -r -d '' dir; do
-      log_debug "Copying dir: $dir"
-      cp -rf "$source_dir/node_modules/$dir" "$deb_dir/usr/share/$package_name/app/node_modules/"
-    done
-  }
-fi
+app_dir="$deb_dir/usr/share/$package_name/app"
 
-if ! [ -f "$deb_dir/usr/share/$package_name/app/package.json" ]; then
+if ! [ -f "$app_dir/package.json" ]; then
   log_info "Including 'package.json' in the Debian package."
   cp -pf './package.json' "$deb_dir/usr/share/$package_name/app/"
 fi
 
-if [ -f './npm-shrinkwrap.json' ] && ! [ -f "$deb_dir/usr/share/$package_name/app/npm-shrinkwrap.json" ]; then
+if [ -f './npm-shrinkwrap.json' ]; then
   log_info "Including 'npm-shrinkwrap.json' in the Debian package."
-  cp -pf './npm-shrinkwrap.json' "$deb_dir/usr/share/$package_name/app/"
+  cp -pf './npm-shrinkwrap.json' "$app_dir"
 fi
+
+if [ -f './yarn.lock' ]; then
+  log_info "Including 'yarn.lock' in the Debian package."
+  cp -pf './yarn.lock' "$app_dir"
+fi
+
+cd "$app_dir"
+if [ -f "./yarn.lock" ]; then
+  log_info "Building node_modules dir with yarn"
+  yarn install --no-progress --production 2>&1 > /dev/null | sed "s/^/YARN: /"
+else
+  log_info "Building node_modules dir with npm"
+  npm install --no-progress --production  2>&1 > /dev/null | sed "s/^/NPM:  /"
+fi
+cd "$source_dir"
 
 # Calculate md5sums
 log_debug 'Calculating md5 sums'

--- a/templates/postinst
+++ b/templates/postinst
@@ -90,7 +90,7 @@ npm_install '{{ node_deb_package_name }}'
 
 mkdir -p '/var/log/{{ node_deb_package_name }}'
 
-chown -R '{{ node_deb_user }}:{{ node_deb_group }}' '/var/log/{{ node_deb_package_name }}'
+chown -R '{{ node_deb_user }}:{{ node_deb_group }}' '/var/log/{{ node_deb_package_name }}' '/usr/share/{{ node_deb_package_name }}/app'
 
 if [[ "$init_type" == 'auto' ]] || [[ "$init_type" == 'systemd' ]] || [[ "$init_type" == 'upstart' ]]; then
   start_service '{{ node_deb_package_name }}'


### PR DESCRIPTION
I know you’ve just changed the behaviour and I know i just created the *various-fixes* PR, that should’ve fixed the `npm ls --prod` line (it didn’t, the `-d ""` option still breaks it… must’ve slipped while tinkering with it), but I think this is a far more fool-proof way of installing the prod dependencies. see the commit message below:

instead of selectively copying files from the existing node_modules dir
and assuming that:
* all necessary packages have been installed
* there is a full understanding of how npm handles the node_modules dir
populate a new node_modules folder with production dependencies only.

this fixes two problems:
* the .bin directory did not exist, because it was not part of the `npm
ls` output
* using yarn didn’t work anymore because the directory structure
doesn’t
   seem to be fully compatible with the one npm creates