### PR TITLE
Fix/node modules bug

### DIFF
--- a/node-deb
+++ b/node-deb
@@ -684,10 +684,12 @@ find "$@" -type f -print0 | {
 }
 
 if [ -d "$source_dir/node_modules" ]; then
-  npm ls --parseable --prod | sed -e "s/$(escape "$source_dir")//g" | grep -Ev '^$' | sed -e 's:/node_modules/::g' | {
-    while IFS="\n" read -r -d '' dir; do
+  npm ls --parseable --prod | sed -e "s/$(escape "$source_dir")//g" | grep -Ev '^$' | sed -e 's/^\/node_modules//g' | {
+    while IFS="\n" read -r dir; do
       log_debug "Copying dir: $dir"
-      cp -rf "$source_dir/node_modules/$dir" "$deb_dir/usr/share/$package_name/app/node_modules/"
+      target_dir=$deb_dir/usr/share/$package_name/app/node_modules$dir
+      mkdir -p $target_dir
+      cp `find "$source_dir/node_modules$dir" -maxdepth 1 -type f` "$target_dir"
     done
   }
 fi

--- a/test/nested-project/package.json
+++ b/test/nested-project/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "nested-project",
+  "version": "1.0.0",
+  "description": "Cannot be empty",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "nodejs index.js"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "jsonwebtoken": "^7.3.0"
+  }
+}


### PR DESCRIPTION
- Fixing an issue where npm modules having their own node_module dirs caused the final deb package to contain no node_modules at all.
- Adding test case for this. I discovered this as jsonwebtoken npm module that I use triggers error.