### PR TITLE
Add support for package-lock.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ However, if you don't like these, there are two options for overrides: command l
 `node_deb` at the top level of your `package.json`. A full explanation of the different options can be found by
 running `node-deb --help`.
 
-By default, if any of the following files exist, they will be included in the Debian package: `package.json` and
-`npm-shrinkwrap.json`.
+By default, if any of the following files exist, they will be included in the Debian package: `package.json`,
+`npm-shrinkwrap.json` and `package-lock.json`.
 
 For example, here are some sample `node_deb` overrides. The full list can be found by running
 `node-deb --list-json-overrides`.
@@ -105,7 +105,7 @@ On install, you will get.
 
 You will get:
 - A Debian package named `some-other-app_20150826_all.deb`
-  - Containing the files `index.js`, `package.json`, & `npm-shrinkwrap.json` and the directories `lib` &
+  - Containing the files `index.js`, `package.json`, & `npm-shrinkwrap.json|package-lock.json` and the directories `lib` &
     `node_modules`
   - Installed via
     - `apt-get install some-other-app`
@@ -146,7 +146,7 @@ On install, you will get.
 
 You will get:
 - A Debian package named `a-third-app_0.10.1_all.deb`
-  - Containing the files `index.js`, `package.json`, & `npm-shrinkwrap.json` and the directories `lib` &
+  - Containing the files `index.js`, `package.json`, & `npm-shrinkwrap.json|package-lock.json` and the directories `lib` &
     `node_modules`
   - With additional dependencies on `apparmor` and `tor`
   - Installed via

--- a/node-deb
+++ b/node-deb
@@ -745,6 +745,11 @@ if echo "$@" | grep -q 'npm-shrinkwrap.json'; then
     'command line.'
 fi
 
+if echo "$@" | grep -q 'package-lock.json'; then
+  log_warn "Since node-deb v0.10.0, 'package-lock.json' is automatically included and should not be specified on the" \
+    'command line.'
+fi
+
 # copy the main files
 find "$@" -type d -print0 | {
   while IFS= read -r -d '' dir; do
@@ -801,6 +806,11 @@ fi
 if ! [ -f "$deb_dir/usr/share/$package_name/app/package.json" ]; then
   log_info "Including 'package.json' in the Debian package."
   cp -pf './package.json' "$deb_dir/usr/share/$package_name/app/"
+fi
+
+if [ -f './package-lock.json' ] && ! [ -f "$deb_dir/usr/share/$package_name/app/package-lock.json" ]; then
+  log_info "Including 'package-lock.json' in the Debian package."
+  cp -pf './package-lock.json' "$deb_dir/usr/share/$package_name/app/"
 fi
 
 if [ -f './npm-shrinkwrap.json' ] && ! [ -f "$deb_dir/usr/share/$package_name/app/npm-shrinkwrap.json" ]; then


### PR DESCRIPTION
This should not affect install strategy, in NPM 5, package-lock.json is treated very much the same way as npm-shrinkwrap.json