### PR TITLE
Remove folder "node_modules" from the prerm script

### DIFF
--- a/templates/prerm
+++ b/templates/prerm
@@ -26,4 +26,4 @@ if [[ "$init_type" == 'auto' || "$init_type" == 'systemd' || "$init_type" == 'up
   fi
 fi
 
-rm -rf /usr/share/$service_name/app/node_modules
+rm -rf "/usr/share/$service_name/app/node_modules"

--- a/templates/prerm
+++ b/templates/prerm
@@ -25,3 +25,5 @@ if [[ "$init_type" == 'auto' || "$init_type" == 'systemd' || "$init_type" == 'up
     echo 'Unless these systems were removed since install, no processes have been left running'
   fi
 fi
+
+rm -rf /usr/share/$service_name/app/node_modules

--- a/test/dog-food.sh
+++ b/test/dog-food.sh
@@ -27,3 +27,5 @@ dpkg -i "node-deb_${node_deb_version}_all.deb"
 node-deb --verbose \
          -- node-deb templates/
 apt-get purge -y node-deb
+
+[ ! -d "/usr/share/node-deb" ] || die "Can't remove /usr/share/node-deb"


### PR DESCRIPTION
It's necessary to remove directory /usr/share/$app
during the uninstall process

Should fix the bug #64 