### PR TITLE
Feature Added: --no-default-dependencies flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,44 @@ On install, you will get.
 - No `upstart`, `systemd`, or `sysv` scripts
 - No Unix user or group
 
+#### Ex. 4
+`package.json`:
+
+```json
+{
+  "name": "a-forth-app",
+  "version": "0.10.1",
+  "node_deb": {
+    "init": "none",
+    "dependencies": "apparmor, tor, nodejs",
+    "templates": {
+      "postinst": "my-teplates/my-postinst-template.txt"
+    },
+    "entrypoints": {
+      "cli": "app.js"
+    }
+  }
+}
+```
+
+`cmd`: `node-deb --no-default-package-dependencies -- app.js lib/`
+
+You will get:
+- A Debian package named `a-forth-app_0.10.1_all.deb`
+  - Containing the files `index.js`, `package.json`, & `npm-shrinkwrap.json|package-lock.json` and the directories `lib` &
+    `node_modules`
+  - With dependencies on `apparmor`, `tor` and `nodejs` only. No default dependencies added
+  - Installed via
+    - `apt-get install a-forth-app`
+    - `apt-get install a-forth-app=0.10.1`
+  - With the `postinst` script rendered from the template `my-postinst-template.txt`
+
+On install, you will get.
+- An executable named `a-forth-app`
+  - That starts the app with the command `app.js`
+- No `upstart`, `systemd`, or `sysv` scripts
+- No Unix user or group
+
 #### &c.
 
 Note: Removal via `apt-get purge` will attempt to remove the user and group defined in the Debian package.

--- a/node-deb
+++ b/node-deb
@@ -206,6 +206,11 @@ while [ -n "$1" ]; do
       package_dependencies="$value"
       shift
       ;;
+    --no-default-package-dependencies)
+      # HELPDOC: Do not add default package depndencies.
+      no_default_package_dependencies=1
+      shift
+      ;;
     -u | --user)
       # HELPDOC: The Unix user the process will run as (default: 'node_deb.user' from package.json then $package-name)
       zero_check "$value" "$param"
@@ -417,11 +422,16 @@ log_debug "The package maintainer has been set to: $package_maintainer"
 # Set the package dependencies
 if [ -z "$package_dependencies" ]; then
   package_dependencies=$(jq -r '.node_deb.dependencies' package.json)
-  if [[ "$package_dependencies" == 'null' ]]; then
-    package_dependencies="nodejs, sudo"
+  default_package_dependencies="nodejs, sudo"
+  if [[ "$package_dependencies" != 'null' ]]; then
+    default_package_dependencies="${default_package_dependencies}, "
   else
-    package_dependencies="nodejs, sudo, $package_dependencies"
+    package_dependencies=""
   fi
+  if [[ $no_default_package_dependencies == 1 ]]; then
+    default_package_dependencies=""
+  fi
+  package_dependencies="${default_package_dependencies}${package_dependencies}"
 fi
 log_debug "The package dependencies has been set to: $package_dependencies"
 

--- a/test.sh
+++ b/test.sh
@@ -24,6 +24,7 @@ declare -ar all_tests=('simple'
                        'commandline-override'
                        'extra-files'
                        'no-init'
+                       'no-default-dependencies'
                        'real-app'
                        'real-cli')
 

--- a/test/no-default-dependencies/app/app.sh
+++ b/test/no-default-dependencies/app/app.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -eu
+
+declare -r target_file='/var/log/no-init/TEST_OUTPUT'
+mkdir -p "$(dirname "$target_file")"
+
+touch "$target_file"

--- a/test/no-default-dependencies/app/package.json
+++ b/test/no-default-dependencies/app/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "no-default-dependencies",
+  "version": "0.1.0",
+  "description": "foo",
+  "author": "foo <bar@baz.quux>",
+  "private": true,
+  "scripts": {
+    "test": "/bin/true"
+  },
+  "node_deb": {
+    "init": "none",
+    "entrypoints": {
+      "cli": "app.sh"
+    },
+    "dependencies": "nodejs"
+  }
+}

--- a/test/no-default-dependencies/test.sh
+++ b/test/no-default-dependencies/test.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -euo pipefail
+
+cd "$(dirname $0)/app"
+source '../../test-helpers.sh'
+
+declare -r output='no-default-dependencies_0.1.0_all'
+
+finish() {
+  rm -rf "$output" *.deb
+}
+
+../../../node-deb --no-default-package-dependencies \
+                  --verbose \
+                  -- app.sh
+
+list_groups() {
+  cut -d: -f1 /etc/group | sort
+}
+
+list_users() {
+  cut -d: -f1 /etc/passwd | sort
+}
+
+old_groups=$(list_groups)
+declare -r old_groups
+
+old_users=$(list_users)
+declare -r old_users
+
+[[ "$(dpkg -I "$output.deb" | grep Depends)" == " Depends: nodejs" ]] || die 'Dependencies invalid'
+dpkg -i "$output.deb"
+sleep 1
+
+[[ "$(list_groups)" == "$old_groups" ]] || die 'Groups unequal'
+[[ "$(list_users)" == "$old_users" ]] || die 'Users unequal'
+
+declare -r target_file='/var/log/no-init/TEST_OUTPUT'
+
+[ ! -f "$target_file" ] || die 'Target file present when it should not have been'
+no-default-dependencies || die 'Could not run executable'
+[ -f "$target_file" ]   || die 'Target file not present when it should have been'
+
+apt-get purge -y no-default-dependencies


### PR DESCRIPTION
Sometimes we do not want to have default dependencies on nodejs and sudo added. Popular cases: peer dependencies, unnecessary dependency on sudo in case when "init": "none". With flag  --no-default-dependencies a developer can completely control dependency list