### PR TITLE
Fixed unnecessary daemon command line escaping in upstart.conf

### DIFF
--- a/templates/upstart.conf
+++ b/templates/upstart.conf
@@ -13,5 +13,5 @@ chdir '/usr/share/{{ node_deb_package_name }}'
 # start the process
 script
   . "/etc/default/{{ node_deb_package_name }}"
-  exec sudo -u '{{ node_deb_user }}' 'app/{{ daemon_entrypoint }}'
+  exec sudo -u '{{ node_deb_user }}' app/{{ daemon_entrypoint }}
 end script


### PR DESCRIPTION
The documentation shows a basic configuration that has the `daemon` command with optional parameters. Unfortunately in case of parameters, the upstart configuration will be wrong because the command will be quoted.

Let's see the following case:
```
{
  "name": "some-app",
  ...
  "node_deb": {
    "version": "1.2.3-beta",
    "entrypoints": {
      "daemon": "foo.js --config /etc/some-app/config.js"
    }
  }
}
```

Will generate an upstart config like this:
```
...
# start the process
script
  . "/etc/default/some-app"
  exec sudo -u 'some-app' 'app/foo.js --config /etc/some-app/config.js'
end script
```

And when `initctl` executes the command it will die due to the quoting with 
```
sudo: app/foo.js --config /etc/some-app/config.js: command not found
```