### PR TITLE
add SyslogIdentifier option to systemd.service

### DIFF
--- a/templates/systemd.service
+++ b/templates/systemd.service
@@ -13,6 +13,7 @@ ExecReload=/bin/kill -HUP $MAINPID
 Restart=always
 User={{ node_deb_user }}
 PermissionsStartOnly=true
+SyslogIdentifier={{ node_deb_package_name }}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Adding `SyslogIdentifier` to `systemd.service` will make logs prettier :)
It will go from this
```
Jun 08 09:45:24 hostname index.js[46800]: Some log line
```
To this
```
Jun 08 09:45:24 hostname my-service[46800]: Some log line
```
It will rename process name to package name